### PR TITLE
Fix sass `:export` keyword

### DIFF
--- a/packages/gatsby-plugin-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/gatsby-node.js
@@ -26,7 +26,7 @@ exports.onCreateWebpackConfig = (
   const sassRule = {
     test: sassRuleTest || /\.s(a|c)ss$/,
     use: isSSR
-      ? [loaders.null()]
+      ? [loaders.css({ ...cssLoaderOptions, importLoaders: 2 })]
       : [
           loaders.miniCssExtract(),
           loaders.css({ ...cssLoaderOptions, importLoaders: 2 }),


### PR DESCRIPTION
## Description

This change fixes the sass `:export` keyword; exported variables are currently undefined on the initial page load in production (but work fine in development).

## Related Issues

Fixes issue #19563
Related to #10706
